### PR TITLE
[#167542805] Fix prepare command

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build": "babel -d lib/ src/",
-    "prepare": "npm run-scripts build",
+    "prepare": "npm run build",
     "prepublish": "./node_modules/.bin/babel -d lib/ src/",
     "dev": "node server.js"
   },


### PR DESCRIPTION
This should fix the `npm install` issue under node 10.

It looks like the base repo might have addressed some of the issues that caused us to fork this repo - we might want to look into switching back.

If we stick with our own version, we might want to:
- Reconcile the dev/master branches
- Build to npmjs.org